### PR TITLE
[fix]: Fixed black bright color

### DIFF
--- a/Tender.itermcolors
+++ b/Tender.itermcolors
@@ -189,13 +189,13 @@
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.11372549086809158</real>
+		<real>0.522918701171875</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.11372549086809158</real>
+		<real>0.522918701171875</real>
 		<key>Red Component</key>
-		<real>0.11372549086809158</real>
+		<real>0.522918701171875</real>
 	</dict>
 	<key>Ansi 9 Color</key>
 	<dict>


### PR DESCRIPTION
**Autocompletion color before fix**:
<img width="321" alt="image" src="https://user-images.githubusercontent.com/101672047/235646153-026ccb32-7236-4c71-b461-96a22e16a156.png">

**Autocompletion color after fix**:

<img width="310" alt="image" src="https://user-images.githubusercontent.com/101672047/235646290-77dad045-968b-4abe-ab3b-abc09087ea49.png">
